### PR TITLE
Fix matrix_key as a string literal instead of a value reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ ${error}`;
     core.setOutput('result', JSON.stringify(outputs_struct))
 
     if (!isEmptyInput(outputs)) {
-        const artifact_content = isEmptyInput(matrix_key) ? outputs_struct : { matrix_key: outputs_struct }
+        const artifact_content = isEmptyInput(matrix_key) ? outputs_struct : { [matrix_key]: outputs_struct }
 
         fs.writeFileSync("./" + step_name, JSON.stringify(artifact_content));
         const fileBuffer = fs.readFileSync("./" + step_name);


### PR DESCRIPTION
The json creation was using `"matrix_key"` as a string literal instead of referencing the `matrix_key` variable that gets set from the input. This PR fixes the issue.

Before this action on `v0.4.0` would write the following json:
```json
{"matrix_key":{"url":"https://frontend-auth.url.com/","paths":"Application:\n","fd_name":"frontend-auth"}}
```

With this PR it writes the following, which matches the behavior of `v0.3.1`:
```json
{"frontend-auth":{"url":"https://frontend-auth.url.com/","paths":"Application:\n","fd_name":"frontend-auth"}}
```

This was tested on a private repository so I can't share the full build, but hopefully the above is enough information.

Related slack message in SweetOps Slack: https://sweetops.slack.com/archives/CQA2BH8AG/p1682360941807629?thread_ts=1681319531.187979&cid=CQA2BH8AG

---

We should probably update the release notes of `v0.4.0` to indicate that it is a broken version and is not compatible with the `github-action-matrix-outputs-read` action.

cc: @goruha 