### PR TITLE
Fix non-matrix mode

### DIFF
--- a/.github/workflows/test-negative.yml
+++ b/.github/workflows/test-negative.yml
@@ -38,7 +38,6 @@ jobs:
           echo "result=$(ls | wc -l)" >> $GITHUB_OUTPUT
 
     outputs:
-      outcome: "${{ steps.current.outcome }}"
       result: "${{ steps.current.outputs.result }}"
 
   assert:
@@ -49,11 +48,6 @@ jobs:
         with:
           expected: '0'
           actual: "${{ needs.test.outputs.result }}"
-
-      - uses: nick-fields/assert-action@v1
-        with:
-          expected: 'failure'
-          actual: "${{ needs.test.outputs.outcome }}"
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-negative.yml
+++ b/.github/workflows/test-negative.yml
@@ -38,6 +38,7 @@ jobs:
           echo "result=$(ls | wc -l)" >> $GITHUB_OUTPUT
 
     outputs:
+      outcome: "${{ steps.current.outcome }}"
       result: "${{ steps.current.outputs.result }}"
 
   assert:
@@ -48,6 +49,11 @@ jobs:
         with:
           expected: '0'
           actual: "${{ needs.test.outputs.result }}"
+
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: 'failure'
+          actual: "${{ needs.test.outputs.outcome }}"
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-non-matrix.yml
+++ b/.github/workflows/test-non-matrix.yml
@@ -30,6 +30,7 @@ jobs:
 
     outputs:
       result: "${{ steps.current.outputs.result }}"
+      outcome: "${{ steps.current.outcome }}"
 
   assert:
     runs-on: ubuntu-latest
@@ -39,6 +40,12 @@ jobs:
         with:
           expected: '{"result":"one"}'
           actual: "${{ needs.test.outputs.result }}"
+
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: 'success'
+          actual: "${{ needs.test.outputs.outcome }}"
+
 
       - uses: nick-fields/assert-action@v1
         with:

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -52,6 +52,7 @@ jobs:
 
     outputs:
       result: "${{ steps.current.outputs.result }}"
+      outcome: "${{ steps.current.outcome }}"
 
   assert:
     runs-on: ubuntu-latest
@@ -62,6 +63,10 @@ jobs:
           expected: '2'
           actual: "${{ needs.test.outputs.result }}"
 
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: 'success'
+          actual: "${{ needs.test.outputs.outcome }}"
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-reusable-workflow.yml
+++ b/.github/workflows/test-reusable-workflow.yml
@@ -29,6 +29,7 @@ jobs:
           echo "result=$(ls | wc -l)" >> $GITHUB_OUTPUT
 
     outputs:
+      outcome: "${{ steps.current.outcome }}"
       result: "${{ steps.current.outputs.result }}"
 
   assert:
@@ -39,6 +40,11 @@ jobs:
         with:
           expected: '2'
           actual: "${{ needs.test.outputs.result }}"
+
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: 'success'
+          actual: "${{ needs.test.outputs.outcome }}"
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-special-chars.yml
+++ b/.github/workflows/test-special-chars.yml
@@ -94,6 +94,7 @@ jobs:
           echo "result=$(ls | wc -l)" >> $GITHUB_OUTPUT
 
     outputs:
+      outcome: "${{ steps.current.outcome }}"
       result: "${{ steps.current.outputs.result }}"
 
   assert:
@@ -104,6 +105,11 @@ jobs:
         with:
           expected: '2'
           actual: "${{ needs.test.outputs.result }}"
+
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: 'success'
+          actual: "${{ needs.test.outputs.outcome }}"
 
 
   teardown:

--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ try {
         return
     }
 
+    const matrix_mode = !isEmptyInput(step_name) && !isEmptyInput(matrix_key)
+
     if (!isEmptyInput(outputs)) {
         try {
             yaml.parse(outputs)
@@ -61,7 +63,7 @@ ${error}`;
 
     core.setOutput('result', JSON.stringify(outputs_struct))
 
-    if (!isEmptyInput(outputs)) {
+    if (!isEmptyInput(outputs) && matrix_mode) {
         const artifact_content = isEmptyInput(matrix_key) ? outputs_struct : { [matrix_key]: outputs_struct }
 
         fs.writeFileSync("./" + step_name, JSON.stringify(artifact_content));


### PR DESCRIPTION
## what
* Fix  the action fail if `matrix-step-name` is empty, which is the correct input for `non-matrix` mode

## why
* Fix 
    - https://github.com/cloudposse/example-app-on-ecs/actions/runs/5081215074
    - https://github.com/cloudposse/example-app-on-eks-with-argocd/actions/runs/5080777018


## Ref
* ttps://github.com/cloudposse/github-actions-workflows/blob/main/.github/workflows/ci-dockerized-app-promote.yml 