### PR TITLE
chore(): Update node version to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ outputs:
   result:
     description: "Outputs result (Deprecated!!!)"
 runs:
-  using: "node16"
+  using: "node20"
   main: "index.js"


### PR DESCRIPTION
## what
* Updates Node version used by this action to v20

## why
* v16 is EOL and Github deprecated it: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ 

## references
* https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
