### PR TITLE
chore: bump node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ outputs:
   result:
     description: "Outputs result (Deprecated!!!)"
 runs:
-  using: "node16"
+  using: "node20"
   main: "index.js"


### PR DESCRIPTION
## what
* bump action from `node16` to `node20`

## why
* https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

