### PR TITLE
feat: specify artifact name

### DIFF
--- a/.github/workflows/test-artifact-name.yml
+++ b/.github/workflows/test-artifact-name.yml
@@ -1,0 +1,111 @@
+name: Test example artifact name overridden
+on:
+  push:
+#  # Uncomment when test added first time to register workflow and comment it back after workflow would be registered
+#  #
+#  # Added pull_request to register workflow from the PR.
+#  # Read more https://stackoverflow.com/questions/63362126/github-actions-how-to-run-a-workflow-created-on-a-non-master-branch-from-the-wo
+#  pull_request: {}
+  workflow_dispatch: {}
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ["one", "two"]
+    steps:
+      - name: Setup
+        run: echo "Do setup"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: ./
+        id: writer
+        with:
+          matrix-step-name: setup1
+          matrix-key: ${{ matrix.target }}
+          artifact-name: setup1
+          outputs: |-
+            result: ${{ matrix.target }}
+            test: existing_value
+
+      - uses: nick-fields/assert-action@v2
+        with:
+          expected: ${{ matrix.target }}
+          actual: ${{ fromJson(steps.writer.outputs.result).result }}
+
+      - uses: nick-fields/assert-action@v2
+        with:
+          expected: existing_value
+          actual: ${{ fromJson(steps.writer.outputs.result).test }}
+
+  setup2:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ["one", "two"]
+    steps:
+      - name: Setup
+        run: echo "Do setup"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: ./
+        id: writer
+        with:
+          matrix-step-name: setup2
+          matrix-key: ${{ matrix.target }}
+          artifact-name: setup2
+          outputs: |-
+            result: ${{ matrix.target }}
+            test: existing_value
+
+      - uses: nick-fields/assert-action@v2
+        with:
+          expected: ${{ matrix.target }}
+          actual: ${{ fromJson(steps.writer.outputs.result).result }}
+
+      - uses: nick-fields/assert-action@v2
+        with:
+          expected: existing_value
+          actual: ${{ fromJson(steps.writer.outputs.result).test }}
+
+  test:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: [setup]
+    steps:
+      - uses: actions/download-artifact@v4
+
+      - id: current
+        run: |-
+          echo "result=$(ls | wc -l)" >> $GITHUB_OUTPUT
+
+    outputs:
+      result: "${{ steps.current.outputs.result }}"
+      outcome: "${{ steps.current.outcome }}"
+
+  assert:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: nick-fields/assert-action@v2
+        with:
+          expected: '4'
+          actual: "${{ needs.test.outputs.result }}"
+
+      - uses: nick-fields/assert-action@v2
+        with:
+          expected: 'success'
+          actual: "${{ needs.test.outputs.outcome }}"
+
+  teardown:
+    runs-on: ubuntu-latest
+    needs: [assert]
+    if: ${{ always() }}
+    steps:
+      - name: Tear down
+        run: echo "Do Tear down"

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   matrix-key:
     required: false
     description: "Matrix key"
+  artifact-name:
+    required: false
+    description: "Override the name used to store the artifact (default is a hash of the content)"
   outputs:
     required: false
     description: "YAML structured map of outputs"

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 try {
     const step_name = core.getInput('matrix-step-name');
     const matrix_key = core.getInput('matrix-key');
+    const artifact_name = core.getInput('artifact-name');
     const outputs = core.getInput('outputs');
 
     core.debug("step_name:")
@@ -14,6 +15,9 @@ try {
 
     core.debug("matrix_key:")
     core.debug(matrix_key)
+
+    core.debug("artifact_name:")
+    core.debug(artifact_name)
 
     core.debug("outputs:")
     core.debug(outputs)
@@ -74,7 +78,7 @@ ${error}`;
         const hex = hashSum.digest('hex');
 
         const artifactClient = new DefaultArtifactClient();
-        const artifactName = hex;
+        const artifactName = isEmptyInput(artifact_name) ? hex : artifact_name + matrix_key;
         const files = [
             "./" + step_name,
         ]


### PR DESCRIPTION
## what
An optional input `artifact-name` is added to allow the user to specify how to name the artifacts stored.
If the input is missing, the hash is used as before.

## why
Due to the use of a hash of the content as an artifact name, if different steps (with a different step name) try to use the action to write the same content, the build will fail. The first step will succeed but the second one will fail because an artifact with the same name already exists.

## references
Fixes #44 